### PR TITLE
Local development issues fixed.

### DIFF
--- a/build.js
+++ b/build.js
@@ -15,7 +15,7 @@ console.log('Building Pixel Editor');
 
 
 function copy_images(){
-    gulp.src('./images/')
+    gulp.src('./images/*.png')
         .pipe(gulp.dest(path.join(BUILDDIR, SLUG)));
 }
 

--- a/server.js
+++ b/server.js
@@ -12,11 +12,7 @@ app.get('/', (req, res) => {
         if(err){
             console.log('error sending file',err);
         } else {
-            setTimeout(()=>{
-                console.log('closing server');
-                server.close();
-                process.exit();
-            },1000*10);
+            console.log("Server: Successfully served index.html");
         }
     });
 });


### PR DESCRIPTION
### Local Server Crashing
The local server crashed soon after launching. There was a setTimeout function that was terminating the server soon after serving the root route. I took it out and replaced it with a helpful message.

### Missing Local Dev Env Tools Images
The tool images work properly on the hosted site but in the dev environment the images are missing. I had to adjust the gulp task to look for *.png files and place them in the build folder.