### PR TITLE
Move brushPreview with canvas when panning with mousewheel

### DIFF
--- a/js/_mouseEvents.js
+++ b/js/_mouseEvents.js
@@ -38,6 +38,7 @@ window.addEventListener("mousedown", function (mouseEvent) {
 	}
 	else if (mouseEvent.which == 2) {
 		currentTool = tool.pan;
+		tool.pan.brushSize = currentToolTemp.brushSize;
 	}
 	else if (currentTool.name == 'pencil' && mouseEvent.which == 3) {
 		currentTool = tool.resizebrush;
@@ -171,6 +172,8 @@ window.addEventListener("mouseup", function (mouseEvent) {
 	currentTool = currentToolTemp;
 
 	currentTool.updateCursor();
+	var cursorLocation = getCursorPosition(mouseEvent);
+	currentTool.moveBrushPreview(cursorLocation);
 
 
 }, false);

--- a/js/_mouseEvents.js
+++ b/js/_mouseEvents.js
@@ -37,8 +37,8 @@ window.addEventListener("mousedown", function (mouseEvent) {
 		}
 	}
 	else if (mouseEvent.which == 2) {
+		tool.pan.brushSize = currentTool.brushSize;
 		currentTool = tool.pan;
-		tool.pan.brushSize = currentToolTemp.brushSize;
 	}
 	else if (currentTool.name == 'pencil' && mouseEvent.which == 3) {
 		currentTool = tool.resizebrush;

--- a/js/_mouseEvents.js
+++ b/js/_mouseEvents.js
@@ -217,8 +217,6 @@ function draw (mouseEvent) {
 		//if a document hasnt yet been created or the current layer is locked, exit this function
 		if (!documentCreated || dialogueOpen || !currentLayer.isVisible || currentLayer.isLocked) return;
 
-		// Moving brush preview
-		currentTool.moveBrushPreview(cursorLocation);
 		// Hiding eyedropper, will be shown if it's needed
 		eyedropperPreview.style.display = 'none';
 
@@ -307,6 +305,9 @@ function draw (mouseEvent) {
 			for (let i=1; i<layers.length; i++) {
 				layers[i].copyData(layers[0]);
 			}
+			// Updating cursorLocation with new layer position
+			lastMouseMovePos = getCursorPosition(mouseEvent);
+			cursorLocation = lastMouseMovePos;
 		}
 		else if (currentTool.name == 'eyedropper' && dragging && mouseEvent.target.className == 'drawingCanvas') {
 			let selectedColor = getEyedropperColor(cursorLocation);
@@ -420,6 +421,9 @@ function draw (mouseEvent) {
 			}
 			currentLayer.updateLayerPreview();
 		}
+
+		// Moving brush preview
+		currentTool.moveBrushPreview(cursorLocation);
 	}
 
 	if (mouseEvent.target.className == 'drawingCanvas')

--- a/js/_tools.js
+++ b/js/_tools.js
@@ -18,10 +18,10 @@ class Tool {
 
 		if (options.imageCursor) this.cursor = "url(\'/pixel-editor/"+options.imageCursor+".png\'), auto";
 
+		this.currentBrushSize = 1;
+		this.previousBrushSize = 1;
 		if (options.brushPreview) {
 			this.brushPreview = true;
-			this.currentBrushSize = 1;
-			this.previousBrushSize = 1;
 		}
 
 		//add to tool object so it can be referenced


### PR DESCRIPTION
When panning using the mouse wheel, rather than staying in its position, the brushPreview now moves with the canvas, so that it is at the position of the mouse cursor after panning.

Also, when resizing the brush using the right mouse button, the brushPreview now jumps to the position of the mouse cursor directly after resizing.