### PR TITLE
Fixed canvas resizing bug

### DIFF
--- a/js/File.js
+++ b/js/File.js
@@ -3,6 +3,7 @@ class File {
     canvasSize = [];
     zoom = 7;
     canvasView = document.getElementById("canvas-view");
+    inited = false;
 
     // Layers
     layers = [];
@@ -34,11 +35,13 @@ class File {
     // Start resize data
     startData = {width: 0, height:0, widthPercentage: 100, heightPercentage: 100};
 
-    // Sprite scaling attributes
 
     openResizeCanvasWindow() {
+        if (!this.inited) {
+            this.initResizeCanvasInputs();
+            this.inited = true;
+        }
         // Initializes the inputs
-        this.initResizeCanvasInputs();
         Dialogue.showDialogue('resize-canvas');
     }
 
@@ -150,6 +153,9 @@ class File {
                 this.rcBorders.left + this.rcBorders.right;
         currFile.canvasSize[1] = parseInt(currFile.canvasSize[1]) + 
             this.rcBorders.top + this.rcBorders.bottom;
+
+        console.trace();
+        console.log(currFile.canvasSize);
 
         // Resize the canvases
         for (let i=0; i<currFile.layers.length; i++) {

--- a/js/ToolManager.js
+++ b/js/ToolManager.js
@@ -36,7 +36,6 @@ const ToolManager = (() => {
     }
 
     function onMouseWheel(mouseEvent) {
-        console.log("MOUSE WHEEL");
         if (!EditorState.documentCreated || Dialogue.isOpen())
             return;
 


### PR DESCRIPTION
Every time the user opened the window, the events were rebinded and added multiple times. So every popup added a canvas resizing operation.