### PR TITLE
Fixed EyedropperTool bug

### DIFF
--- a/js/ToolManager.js
+++ b/js/ToolManager.js
@@ -8,7 +8,7 @@ const ToolManager = (() => {
     tools["line"] = new LineTool("line", {type: 'html'}, switchTool);
     tools["fill"] = new FillTool("fill", {type: 'cursor', style: 'crosshair'}, switchTool);
     
-    tools["eyedropper"] = new EyedropperTool("eyedropper", {type: 'cursor', style: 'crosshair'}, switchTool);
+    tools["eyedropper"] = new EyeDropperTool("eyedropper", {type: 'cursor', style: 'crosshair'}, switchTool);
     tools["pan"] = new PanTool("pan", {type: 'custom'}, switchTool);
     tools["zoom"] = new ZoomTool("zoom", {type:'custom'});
 

--- a/js/pixel-editor.js
+++ b/js/pixel-editor.js
@@ -38,7 +38,7 @@
 //=include tools/LineTool.js
 //=include tools/RectangleTool.js
 //=include tools/FillTool.js
-//=include tools/EyedropperTool.js
+//=include tools/EyeDropperTool.js
 //=include tools/PanTool.js
 //=include tools/ZoomTool.js
 //=include tools/RectangularSelectionTool.js

--- a/js/tools/EyeDropperTool.js
+++ b/js/tools/EyeDropperTool.js
@@ -1,4 +1,4 @@
-class EyedropperTool extends Tool {
+class EyeDropperTool extends Tool {
     eyedropperPreview = document.getElementById("eyedropper-preview");
     selectedColor = {r:0, g:0, b:0};
 


### PR DESCRIPTION
EyeDropper Tool was not working properly, the reason was the class name. as the class name was wrong there was a bug where the frame would not open.

_some examples of the bug_

**bug**
![pic-selected-220108-0038-38](https://user-images.githubusercontent.com/64911388/148630558-e35f8580-170c-4e79-8ed0-144aa4ad4cd6.png)

**fixed**
![pic-window-220108-0040-50](https://user-images.githubusercontent.com/64911388/148630562-56eaae38-23ed-4763-83f1-fdba0fcdbb10.png)

