### PR TITLE
Only register export click event once (#89)

### DIFF
--- a/js/FileManager.js
+++ b/js/FileManager.js
@@ -27,10 +27,11 @@ const FileManager = (() => {
 
     function openPixelExportWindow() {
         let selectedPalette = Util.getText('palette-button');
+
     
         if (selectedPalette != 'Choose a palette...'){
             var paletteAbbreviation = palettes[selectedPalette].name;
-            var fileName = 'pixel-'+paletteAbbreviation+'-'+canvasSize[0]+'x'+canvasSize[1]+'.png';
+            var fileName = 'pixel-'+paletteAbbreviation+'-'+currFile.canvasSize[0]+'x'+currFile.canvasSize[1]+'.png';
         } else {
             var fileName = 'pixel-'+currFile.canvasSize[0]+'x'+currFile.canvasSize[1]+'.png';
             selectedPalette = 'none';

--- a/js/FileManager.js
+++ b/js/FileManager.js
@@ -6,6 +6,7 @@ const FileManager = (() => {
 
     Events.on('change', browseHolder, loadFile);
     Events.on('change', browsePaletteHolder, loadPalette);
+    Events.on('click', 'export-confirm', exportProject);
 
     function openSaveProjectWindow() {
         //create name
@@ -36,7 +37,6 @@ const FileManager = (() => {
         }
     
         Util.setValue('export-file-name', fileName);
-        Events.on("click", "export-confirm", exportProject);
         Dialogue.showDialogue('export', false);
     }
 


### PR DESCRIPTION
Tiny fix for #89. Instead of adding a click event whenever the export dialogue is opened, the event is added once at the top of FileManager.js

**Edit:** included a fix for another issue I found while testing. Creating a file from quickstart like "new GameBoy" where size was not specified would break the export window.