### PR TITLE
Fix use of non standard path attribute in zoom wheel event

### DIFF
--- a/js/ToolManager.js
+++ b/js/ToolManager.js
@@ -47,8 +47,9 @@ const ToolManager = (() => {
         if (!EditorState.documentCreated || Dialogue.isOpen())
             return;
 
-        const isHoveringMenuElement = !!mouseEvent.path.find(n=>n.id && n.id.includes("-menu"));
-        if(isHoveringMenuElement)return;
+        // Hovering a menu element
+        const path = mouseEvent.composedPath && mouseEvent.composedPath();
+        if (path && !!path.find(n=>n.id && n.id.includes("-menu"))) return;
 
         let mousePos = Input.getCursorPosition(mouseEvent);
         tools["zoom"].onMouseWheel(mousePos, mouseEvent.deltaY < 0 ? 'in' : 'out');


### PR DESCRIPTION
Fix #108.
I chose to go for the standard way only because it has been supported by all major browser for 4 years or more.